### PR TITLE
Make xcode-install list (without --all) not only show the 7 beta

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,4 +9,4 @@ task :spec do
   sh "bundle exec bacon #{specs('**')}"
 end
 
-task default: :specs
+task default: :spec

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -144,9 +144,9 @@ module XcodeInstall
     end
 
     def list_current
-      majors = list_versions.map { |v| v.split('.')[0] }.map { |v| v.split(' ')[0] }
-      majors = majors.select { |v| v.length == 1 }.uniq
-      list_versions.select { |v| v.start_with?(majors.last) }.join("\n")
+      stable_majors = list_versions.reject { |v| /beta/i =~ v }.map { |v| v.split('.')[0] }.map { |v| v.split(' ')[0] }
+      latest_stable_major = stable_majors.select { |v| v.length == 1 }.uniq.sort.last.to_i
+      list_versions.select { |v| v.split('.')[0].to_i >= latest_stable_major }.sort.join("\n")
     end
 
     def list

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -1,0 +1,45 @@
+require File.expand_path('../spec_helper', __FILE__)
+
+module XcodeInstall
+  describe Command::List do
+    before do
+      installer.stubs(:exists).returns(true)
+      installer.stubs(:installed_versions).returns([])
+    end
+
+    def installer
+      @installer ||= Installer.new
+    end
+
+    def fake_xcode(name)
+      fixture = Pathname.new('spec/fixtures/xcode_63.json').read
+      xcode = Xcode.new(JSON.parse(fixture))
+      xcode.stubs(:name).returns(name)
+      xcode
+    end
+
+    def fake_xcodes(*names)
+      xcodes = names.map { |name| fake_xcode(name) }
+      installer.stubs(:xcodes).returns(xcodes)
+    end
+
+    describe '#list' do
+      it 'lists all versions' do
+        fake_xcodes '1', '2.3', '3 some', '4 beta'
+        installer.list.should == "1\n2.3\n3 some\n4 beta"
+      end
+    end
+
+    describe '#list_current' do
+      it 'shows versions from latest version only' do
+        fake_xcodes '2', '3.0', '3.1', '1.1'
+        installer.list_current.should == "3.0\n3.1"
+      end
+
+      it 'shows versions of new beta releases too' do
+        fake_xcodes '5', '6.1', '6', '6.4 beta', '7 beta'
+        installer.list_current.should == "6\n6.1\n6.4 beta\n7 beta"
+      end
+    end
+  end
+end


### PR DESCRIPTION
`xcode-install list` now only returns: `7 beta`

While of course one can use `--all` to see the rest, it would be better if we'd see the list of versions for the latest 'stable' major as well as the bleeding edge.