### PR TITLE
No-nokogiri. Remove last C dependency by parsing pre-release links by hand

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -1,7 +1,6 @@
 require 'fileutils'
 require 'pathname'
 require 'spaceship'
-require 'nokogiri'
 require 'rubygems/version'
 require 'xcode/install/command'
 require 'xcode/install/version'
@@ -202,10 +201,10 @@ module XcodeInstall
     end
 
     def prereleases
-      page = Nokogiri::HTML.parse(spaceship.send(:request, :get, '/xcode/downloads/').body)
-      links = page.xpath('//a').select { |link| link['href'].end_with?('.dmg') }
+      body=spaceship.send(:request, :get, '/xcode/downloads/').body
+      links=body.scan(/<a.+?href="(.+?).dmg".*>(.*)<\/a>/)
 
-      links.map { |pre| Xcode.new_prelease(pre.text.strip.gsub(/.*Xcode /, ''), pre['href']) }
+      links.map { |pre| Xcode.new_prelease(pre[1].strip.gsub(/.*Xcode /, ''), pre[0]) }
     end
 
     def seedlist

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -202,7 +202,7 @@ module XcodeInstall
 
     def prereleases
       body=spaceship.send(:request, :get, '/xcode/downloads/').body
-      links=body.scan(/<a.+?href="(.+?).dmg".*>(.*)<\/a>/)
+      links=body.scan(/<a.+?href="(.+?.dmg)".*>(.*)<\/a>/)
 
       links.map { |pre| Xcode.new_prelease(pre[1].strip.gsub(/.*Xcode /, ''), pre[0]) }
     end

--- a/spec/prerelease_spec.rb
+++ b/spec/prerelease_spec.rb
@@ -3,12 +3,12 @@ require File.expand_path('../spec_helper', __FILE__)
 module XcodeInstall
   describe Installer do
     def fixture(date)
-      Nokogiri::HTML.parse(File.read("spec/fixtures/devcenter/xcode-#{date}.html"))
+      File.read("spec/fixtures/devcenter/xcode-#{date}.html")
     end
 
     def parse_prereleases(date)
       fixture = fixture(date)
-      Nokogiri::HTML.stubs(:parse).returns(fixture)
+      @result.stubs(:body).returns(fixture)
 
       installer = Installer.new
       installer.send(:prereleases)
@@ -19,10 +19,10 @@ module XcodeInstall
       devcenter.stubs(:download_file).returns(nil)
       Installer.any_instance.stubs(:devcenter).returns(devcenter)
 
-      result = mock
-      result.stubs(:body).returns(nil)
+      @result = mock
+      @result.stubs(:body).returns(nil)
       client = mock
-      client.stubs(:request).returns(result)
+      client.stubs(:request).returns(@result)
       Spaceship::Client.stubs(:login).returns(client)
     end
 

--- a/xcode-install.gemspec
+++ b/xcode-install.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'claide', '~> 0.8.1'
   spec.add_dependency 'spaceship', '0.0.11'
-  spec.add_dependency 'nokogiri', '~> 1.3'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Related to #17.

Note: #27 reintroduces nokogiri.