### PR TITLE
[Simulators] added Simulators command

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,35 @@ they have to be installed using the full name, e.g. `xcversion install '7 GM see
 
 XcodeInstall can also install Xcode's Command Line Tools by calling `xcversion install-cli-tools`.
 
+### Simulators
+
+XcodeInstall can also manage your local simulators using the `simulators` command.
+
+```bash
+$ xcode-install simulators
+Xcode 6.4.0 (/Applications/Xcode.app)
+iOS 7.1 Simulator (installed)
+iOS 8.1 Simulator (not installed)
+iOS 8.2 Simulator (not installed)
+iOS 8.3 Simulator (installed)
+Xcode 7.0.0 (/Applications/Xcode-beta.app)
+iOS 8.1 Simulator (not installed)
+iOS 8.2 Simulator (not installed)
+iOS 8.3 Simulator (installed)
+iOS 8.4 Simulator (installed)
+```
+
+To install a simulator, simply:
+
+```bash
+$ xcode-install simulators --install=8.4
+###########################################################               82.1%
+######################################################################## 100.0%
+Please authenticate to install iOS 8.4 Simulator...
+
+Successfully installed iOS 8.4 Simulator
+```
+
 ## Limitations
 
 Unfortunately, the installation size of Xcodes downloaded will be bigger than when downloading via the Mac App Store, see [#10](/../../issues/10) and feel free to dupe the radar. 📡

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -377,6 +377,7 @@ HELP
   class InstalledXcode
     attr_reader :path
     attr_reader :version
+    attr_reader :bundle_version
     attr_reader :uuid
     attr_reader :downloadable_index_url
     attr_reader :available_simulators
@@ -386,7 +387,11 @@ HELP
     end
 
     def version
-      @version ||= Gem::Version.new(plist_entry(':DTXcode').to_i.to_s.split(//).join('.'))
+      @version ||= get_version
+    end
+
+    def bundle_version
+      @bundle_version ||= Gem::Version.new(plist_entry(':DTXcode').to_i.to_s.split(//).join('.'))
     end
 
     def uuid
@@ -394,7 +399,7 @@ HELP
     end
 
     def downloadable_index_url
-      @downloadable_index_url ||= "https://devimages.apple.com.edgekey.net/downloads/xcode/simulators/index-#{version}-#{uuid}.dvtdownloadableindex"
+      @downloadable_index_url ||= "https://devimages.apple.com.edgekey.net/downloads/xcode/simulators/index-#{bundle_version}-#{uuid}.dvtdownloadableindex"
     end
 
     def approve_license

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -1,11 +1,13 @@
 require 'fileutils'
 require 'pathname'
 require 'spaceship'
+require 'json'
 require 'rubygems/version'
 require 'xcode/install/command'
 require 'xcode/install/version'
 
 module XcodeInstall
+  CACHE_DIR = Pathname.new("#{ENV['HOME']}/Library/Caches/XcodeInstall")
   class Curl
     COOKIES_PATH = Pathname.new('/tmp/curl-cookies.txt')
 
@@ -171,7 +173,6 @@ HELP
       end
     end
 
-    CACHE_DIR = Pathname.new("#{ENV['HOME']}/Library/Caches/XcodeInstall")
     LIST_FILE = CACHE_DIR + Pathname.new('xcodes.bin')
     MINIMUM_VERSION = Gem::Version.new('4.3')
     SYMLINK_PATH = Pathname.new('/Applications/Xcode.app')
@@ -267,13 +268,133 @@ HELP
     end
   end
 
+  class Simulator
+    attr_reader :version
+    attr_reader :name
+    attr_reader :identifier
+    attr_reader :source
+    attr_reader :xcode
+
+    def initialize(downloadable)
+      @version = Gem::Version.new(downloadable['version'])
+      @install_prefix = apply_variables(downloadable['userInfo']['InstallPrefix'])
+      @name = apply_variables(downloadable['name'])
+      @identifier = apply_variables(downloadable['identifier'])
+      @source = apply_variables(downloadable['source'])
+    end
+
+    def installed?
+      # FIXME: use downloadables' `InstalledIfAllReceiptsArePresentOrNewer` key
+      File.directory?(@install_prefix)
+    end
+
+    def installed_string
+      installed? ? 'installed' : 'not installed'
+    end
+
+    def to_s
+      "#{name} (#{installed_string})"
+    end
+
+    def xcode
+      Installer.new.installed_versions.find do |x|
+        x.available_simulators.find do |s|
+          s.version == version
+        end
+      end
+    end
+
+    def download
+      result = Curl.new.fetch(source, CACHE_DIR)
+      result ? dmg_path : nil
+    end
+
+    def download
+      result = Curl.new.fetch(source, CACHE_DIR)
+      result ? dmg_path : nil
+    end
+
+    def install
+      download unless dmg_path.exist?
+      prepare_package unless pkg_path.exist?
+      puts "Please authenticate to install #{name}..."
+      `sudo installer -pkg #{pkg_path} -target /`
+      fail Informative, "Could not install #{name}, please try again" unless installed?
+      source_receipts_dir = '/private/var/db/receipts'
+      target_receipts_dir = "#{@install_prefix}/System/Library/Receipts"
+      FileUtils.mkdir_p(target_receipts_dir)
+      FileUtils.cp("#{source_receipts_dir}/#{@identifier}.bom", target_receipts_dir)
+      FileUtils.cp("#{source_receipts_dir}/#{@identifier}.plist", target_receipts_dir)
+      puts "Successfully installed #{name}"
+    end
+
+    :private
+
+    def prepare_package
+      puts 'Mounting DMG'
+      mount_location = `hdiutil mount -nobrowse -noverify #{dmg_path}`.scan(/\/Volumes.*\n/).first.chomp
+      puts 'Expanding pkg'
+      expanded_pkg_path = CACHE_DIR + identifier
+      FileUtils.rm_rf(expanded_pkg_path)
+      `pkgutil --expand #{mount_location}/*.pkg #{expanded_pkg_path}`
+      puts "Expanded pkg into #{expanded_pkg_path}"
+      puts 'Unmounting DMG'
+      `umount #{mount_location}`
+      puts 'Setting package installation location'
+      package_info_path = expanded_pkg_path + 'PackageInfo'
+      package_info_contents = File.read(package_info_path)
+      File.open(package_info_path, 'w') do |f|
+        f << package_info_contents.sub('pkg-info', %(pkg-info install-location="#{@install_prefix}"))
+      end
+      puts 'Rebuilding package'
+      `pkgutil --flatten #{expanded_pkg_path} #{pkg_path}`
+      FileUtils.rm_rf(expanded_pkg_path)
+    end
+
+    def dmg_path
+      CACHE_DIR + Pathname.new(source).basename
+    end
+
+    def pkg_path
+      CACHE_DIR + "#{identifier}.pkg"
+    end
+
+    def apply_variables(template)
+      variable_map = {
+        '$(DOWNLOADABLE_VERSION_MAJOR)' => version.to_s.split('.')[0],
+        '$(DOWNLOADABLE_VERSION_MINOR)' => version.to_s.split('.')[1],
+        '$(DOWNLOADABLE_IDENTIFIER)' => identifier,
+        '$(DOWNLOADABLE_VERSION)' => version.to_s
+      }.freeze
+      variable_map.each do |key, value|
+        next unless template.include?(key)
+        template.sub!(key, value)
+      end
+      template
+    end
+  end
+
   class InstalledXcode
     attr_reader :path
     attr_reader :version
+    attr_reader :uuid
+    attr_reader :downloadable_index_url
+    attr_reader :available_simulators
 
     def initialize(path)
       @path = Pathname.new(path)
-      @version = get_version
+    end
+
+    def version
+      @version ||= Gem::Version.new(plist_entry(':DTXcode').to_i.to_s.split(//).join('.'))
+    end
+
+    def uuid
+      @uuid ||= plist_entry(':DVTPlugInCompatibilityUUID')
+    end
+
+    def downloadable_index_url
+      @downloadable_index_url ||= "https://devimages.apple.com.edgekey.net/downloads/xcode/simulators/index-#{version}-#{uuid}.dvtdownloadableindex"
     end
 
     def approve_license
@@ -285,6 +406,12 @@ HELP
       `sudo /usr/libexec/PlistBuddy -c "add :IDEXcodeVersionForAgreedToGMLicense string #{@version}" #{license_plist_path}`
     end
 
+    def available_simulators
+      @available_simulators ||= JSON.parse(`curl -Ls #{downloadable_index_url} | plutil -convert json -o - -`)['downloadables'].map do |downloadable|
+        Simulator.new(downloadable)
+      end
+    end
+
     def install_components
       `sudo installer -pkg #{@path}/Contents/Resources/Packages/MobileDevice.pkg -target /`
       osx_build_version = `sw_vers -buildVersion`.chomp
@@ -294,6 +421,10 @@ HELP
     end
 
     :private
+
+    def plist_entry(keypath)
+      `/usr/libexec/PlistBuddy -c "Print :#{keypath}" "#{path}/Contents/Info.plist"`.chomp
+    end
 
     def get_version
       output = `DEVELOPER_DIR='' "#{@path}/Contents/Developer/usr/bin/xcodebuild" -version`

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -309,11 +309,6 @@ HELP
       result ? dmg_path : nil
     end
 
-    def download
-      result = Curl.new.fetch(source, CACHE_DIR)
-      result ? dmg_path : nil
-    end
-
     def install
       download unless dmg_path.exist?
       prepare_package unless pkg_path.exist?

--- a/lib/xcode/install/command.rb
+++ b/lib/xcode/install/command.rb
@@ -22,6 +22,7 @@ module XcodeInstall
     require 'xcode/install/selected'
     require 'xcode/install/uninstall'
     require 'xcode/install/update'
+    require 'xcode/install/simulators'
 
     self.abstract_command = true
     self.command = 'xcversion'

--- a/lib/xcode/install/simulators.rb
+++ b/lib/xcode/install/simulators.rb
@@ -34,12 +34,12 @@ module XcodeInstall
       elsif filtered_simulators.count == 1
         simulator = filtered_simulators.first
         fail Informative, "#{simulator.name} is already installed." if simulator.installed?
-        puts "Installing #{simulator.name} for Xcode #{simulator.xcode.version}..."
+        puts "Installing #{simulator.name} for Xcode #{simulator.xcode.bundle_version}..."
         simulator.install
       else
         puts "[!] More than one simulator matching #{@install} was found. Please specify the full version.".ansi.red
         filtered_simulators.each do |simulator|
-          puts "Xcode #{simulator.xcode.version} (#{simulator.xcode.path})".ansi.green
+          puts "Xcode #{simulator.xcode.bundle_version} (#{simulator.xcode.path})".ansi.green
           puts "xcode-install simulator --install=#{simulator.version}"
         end
         exit 1

--- a/lib/xcode/install/simulators.rb
+++ b/lib/xcode/install/simulators.rb
@@ -1,0 +1,58 @@
+require 'claide'
+
+module XcodeInstall
+  class Command
+    class Simulators < Command
+      self.command = 'simulators'
+      self.summary = 'List or install iOS simulators.'
+
+      def self.options
+        [['--install=version', 'Install simulator with the given version.']].concat(super)
+      end
+
+      def initialize(argv)
+        @installed_xcodes = Installer.new.installed_versions
+        @install = argv.option('install')
+        super
+      end
+
+      def run
+        @install ? install : list
+      end
+    end
+
+    :private
+
+    def install
+      filtered_simulators = @installed_xcodes.map { |x| x.available_simulators }.flatten.select do |sim|
+        sim.version.to_s.start_with?(@install)
+      end
+      if filtered_simulators.count == 0
+        puts "[!] No simulator matching #{@install} was found. Please specify a version from the following available simulators:".ansi.red
+        list
+        exit 1
+      elsif filtered_simulators.count == 1
+        simulator = filtered_simulators.first
+        fail Informative, "#{simulator.name} is already installed." if simulator.installed?
+        puts "Installing #{simulator.name} for Xcode #{simulator.xcode.version}..."
+        simulator.install
+      else
+        puts "[!] More than one simulator matching #{@install} was found. Please specify the full version.".ansi.red
+        filtered_simulators.each do |simulator|
+          puts "Xcode #{simulator.xcode.version} (#{simulator.xcode.path})".ansi.green
+          puts "xcode-install simulator --install=#{simulator.version}"
+        end
+        exit 1
+      end
+    end
+
+    def list
+      @installed_xcodes.each do |xcode|
+        puts "Xcode #{xcode.version} (#{xcode.path})".ansi.green
+        xcode.available_simulators.each do |simulator|
+          puts simulator.to_s
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
With a dizzying cocktail of dtrace, lldb, Charles Proxy and Hopper, I was finally able to figure out how get the simulators to download.

Despite the winding road I took to get there, the solution is actually pretty simple.

I haven't tested this extensively, but AFAICT it works well with Xcode 7 beta 4. Xcode 6.4's Preferences->Download pane however displays the simulators as not downloaded though, so I have to fix that before this can be merged. They do show up in the list of available simulators from the devices pane, however.

Of course, I'd like to write specs for this functionality before it's merged as well.

But the implementation itself is ready for review :smile:. I'm still a novice in ruby, so don't hesitate to provide stylistic feedback too.

PS: this approach can also be applied to discover, download, and install docsets & command line tools as well, but that'll be for another PR...