### PR TITLE
automatically accept Xcode license

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -96,7 +96,7 @@ HELP
       end
 
       enable_developer_mode
-      `sudo xcodebuild -license` unless xcode_license_approved?
+      `sudo xcodebuild -license accept` unless xcode_license_approved?
       install_components(xcode_path) if components
 
       if switch


### PR DESCRIPTION
This works when SSHing and doesn't even require displaying UI.

I'd also recommend that the call to `install_components` be replaced with simply `open #{xcode_path}`, since it doesn't seem to currently be working for me (clicking `Install` doesn't work when SSHing I think), but opening Xcode automatically prompts for the tools anyway. So it's the same behavior as when it works, but it just works more often :wink:.