### PR TITLE
Remove wrong install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,6 @@ $ gem install xcode-install
 $ xcversion install 6.3
 ```
 
-## Installation
-
-```bash
-$ gem install xcversion
-```
-
 ## Usage
 
 XcodeInstall needs environment variables with your credentials to access the Apple Developer


### PR DESCRIPTION
Getting errors using `gem install xcversion`.

```
➜  ~  gem install xcversion
ERROR:  Could not find a valid gem 'xcversion' (>= 0) in any repository
ERROR:  Possible alternatives: aversion, version, pgversion, inversion, diversion
```

Also the install instructions are duplicated in line 11.

>Install and update your Xcodes automatically.
>
>```bash
>$ gem install xcode-install
>$ xcversion install 6.3
>```
