### PR TITLE
Fix timing issue when running tests

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -467,7 +467,6 @@ HELP
 
     def self.new_prerelease(version, url, release_notes_path)
       new('name' => version,
-          'dateModified' => Time.now.to_i,
           'files' => [{ 'remotePath' => url.split('=').last }],
           'release_notes_path' => release_notes_path)
     end


### PR DESCRIPTION
Ran into this a few times.

```
Bacon::Error: #<XcodeInstall::Xcode:0x007fcfbd7003c0 @date_modified=1446633908, @name="6.3.2 GM seed", @path="/Developer_Tools/Xcode_6.3.2_GM_seed/Xcode_6.3.2_GM_seed.dmg", @url="https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_6.3.2_GM_seed/Xcode_6.3.2_GM_seed.dmg", @release_notes_url="https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_6.3.2_GM_seed/Xcode_6.3.2_GM_Seed_Release_Notes.pdf", @version=#<Gem::Version "6.3.2">>.==(#<XcodeInstall::Xcode:0x007fcfbd7023f0 @date_modified=1446633909, @name="6.3.2 GM seed", @path="/Developer_Tools/Xcode_6.3.2_GM_seed/Xcode_6.3.2_GM_seed.dmg", @url="https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_6.3.2_GM_seed/Xcode_6.3.2_GM_seed.dmg", @release_notes_url="https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_6.3.2_GM_seed/Xcode_6.3.2_GM_Seed_Release_Notes.pdf", @version=#<Gem::Version "6.3.2">>) failed
  spec/prerelease_spec.rb:45:in `block (2 levels) in <module:XcodeInstall>': XcodeInstall::Installer - can parse prereleases from 20150508
  spec/prerelease_spec.rb:41:in `block in <module:XcodeInstall>'
  spec/prerelease_spec.rb:4:in `<module:XcodeInstall>'
  spec/prerelease_spec.rb:3:in `<top (required)>'
```

Happens in the prerelease-spec when those lines are executed during different seconds of the time:

```
prereleases = parse_prereleases('20150414')
prereleases.should == [Xcode.new_prerelease('6.4', '/Developer_Tools/Xcode_6.4_Beta/Xcode_6.4_beta.dmg', '/Developer_Tools/Xcode_6.4_Beta/Xcode_6.4_beta_Release_Notes.pdf')]
```

I know, this fix doesn't fix the test but changes library code 😱.
The alternative solution would have been to mock `Time.now`.

Semantic implications: This effectively moves items from the
back to the front of the result of `parse_seedlist` if they don't have
a `dateModified` field which doesn't matter as far as I can tell.
This could be prevented by setting `dateModified` to `INT_MAX` or
changing the comparator block to handle `0` differently.