### PR TITLE
Fix exitstatus check and cleanup curl

### DIFF
--- a/spec/curl_spec.rb
+++ b/spec/curl_spec.rb
@@ -1,0 +1,12 @@
+require File.expand_path('../spec_helper', __FILE__)
+
+module XcodeInstall
+  describe Curl do
+    it 'reports failure' do
+      `true`
+      curl = XcodeInstall::Curl.new
+      result = curl.fetch('http://0.0.0.0/test')
+      result.should == false
+    end
+  end
+end


### PR DESCRIPTION
- exitstatus is only set when the `io` is closed
- use popen so that we don't have to care about spaces