### PR TITLE
Allow simulator installs when multiple Xcodes provide the same one

### DIFF
--- a/lib/xcode/install/simulators.rb
+++ b/lib/xcode/install/simulators.rb
@@ -24,7 +24,7 @@ module XcodeInstall
     :private
 
     def install
-      filtered_simulators = @installed_xcodes.map(&:available_simulators).flatten.uniq{|x| x.name}.select do |sim|
+      filtered_simulators = @installed_xcodes.map(&:available_simulators).flatten.uniq(&:name).select do |sim|
         sim.name.start_with?(@install)
       end
       case filtered_simulators.count

--- a/lib/xcode/install/simulators.rb
+++ b/lib/xcode/install/simulators.rb
@@ -7,7 +7,7 @@ module XcodeInstall
       self.summary = 'List or install iOS simulators.'
 
       def self.options
-        [['--install=version', 'Install simulator with the given version.']].concat(super)
+        [['--install=name', 'Install simulator beginning with name, e.g. \'iOS 8.4\', \'tvOS 9.0\'.']].concat(super)
       end
 
       def initialize(argv)
@@ -24,8 +24,8 @@ module XcodeInstall
     :private
 
     def install
-      filtered_simulators = @installed_xcodes.map(&:available_simulators).flatten.select do |sim|
-        sim.version.to_s.start_with?(@install)
+      filtered_simulators = @installed_xcodes.map(&:available_simulators).flatten.uniq{|x| x.name}.select do |sim|
+        sim.name.start_with?(@install)
       end
       case filtered_simulators.count
       when 0


### PR DESCRIPTION
This should address #98. The root cause was that the processed array of available simulators would still contain duplicates, so I passed the simulator names to `uniq` to filter down the array per simulator name. For as long as I've seen DVT simulator downloads, even if a simulator overlaps multiple Xcodes, it's still been the same package, installing the files independently of the Xcode app bundles in `/Library`.

Also, switching to names rather than only version makes it easier to install things like the legacy tvOS simulator.