### PR TITLE
[Install] More helpful output when omitting required argument.

### DIFF
--- a/lib/xcode/install/install.rb
+++ b/lib/xcode/install/install.rb
@@ -32,7 +32,7 @@ module XcodeInstall
       def validate!
         super
 
-        return if @version.nil?
+        help! 'A VERSION argument is required.' unless @version
         fail Informative, "Version #{@version} already installed." if @installer.installed?(@version)
         fail Informative, "Version #{@version} doesn't exist." unless @installer.exist?(@version)
         fail Informative, "Invalid URL: `#{@url}`" unless !@url || @url =~ /\A#{URI.regexp}\z/


### PR DESCRIPTION
### Before

```
$ xcversion install
[!] Failed to download Xcode .
```

### After

```
$ xcversion install  
[!] A VERSION argument is required.

Usage:

    $ xcversion install VERSION

      Install a specific version of Xcode.

Options:

    --url           Custom Xcode DMG file path or HTTP URL.
    --no-switch     Don’t switch to this version after installation
    --no-install    Only download DMG, but do not install it.
    --no-progress   Don’t show download progress.
    --no-clean      Don’t delete DMG after installation.
    --verbose       Show more debugging information
    --no-ansi       Show output without ANSI codes
    --help          Show help banner of specified command
```