### PR TITLE
Check CLI tools installed by libxcrun.dylib instead of `xcode-select -p`

### DIFF
--- a/lib/xcode/install/cli.rb
+++ b/lib/xcode/install/cli.rb
@@ -10,8 +10,7 @@ module XcodeInstall
       end
 
       def installed?
-        `xcode-select -p`
-        $?.success?
+        File.exist?('/Library/Developer/CommandLineTools/usr/lib/libxcrun.dylib')
       end
 
       def install


### PR DESCRIPTION
As indicated in the comments, the mechanism to check CLI tools installation will easily give a false `true` if an Xcode is already installed.

Xcode essentially includes all the CLI tools within its developer dir, but we want to really verify that the dev tools are for real installed, regardless of any Xcodes that may also be installed. I did quite a bit of testing and disassembly that indicates to me that `usr/lib/libxcrun.dylib` has to be present within the CLI tools install dir in order for `xcode-select --switch` to happily switch to it.

Thanks for your consideration!