### PR TITLE
Don't authenticate when there's a custom URL

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -53,7 +53,7 @@ module XcodeInstall
       xcode = seedlist.find { |x| x.name == version }
       dmg_file = Pathname.new(File.basename(url || xcode.path))
 
-      result = Curl.new.fetch(url || xcode.url, CACHE_DIR, spaceship.cookie, dmg_file, progress)
+      result = Curl.new.fetch(url || xcode.url, CACHE_DIR, url ? nil : spaceship.cookie, dmg_file, progress)
       result ? CACHE_DIR + dmg_file : nil
     end
 

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -114,7 +114,7 @@ HELP
 
     def install_version(version, switch = true, clean = true, install = true, progress = true, url = nil)
       dmg_path = get_dmg(version, progress, url)
-      fail Informative, "Failed to download Xcode #{version}." if dmg_path.nil?
+      raise Informative, "Failed to download Xcode #{version}." if dmg_path.nil?
 
       install_dmg(dmg_path, "-#{version.split(' ')[0]}", switch, clean) if install
 
@@ -161,7 +161,7 @@ HELP
       plist = hdiutil('mount', '-plist', '-nobrowse', '-noverify', dmg_path.to_s)
       document = REXML::Document.new(plist)
       node = REXML::XPath.first(document, "//key[.='mount-point']/following-sibling::*[1]")
-      fail Informative, 'Failed to mount image.' unless node
+      raise Informative, 'Failed to mount image.' unless node
       node.text
     end
 
@@ -286,7 +286,7 @@ HELP
       io = IO.popen(['hdiutil', *args])
       result = io.read
       io.close
-      fail Informative, 'Failed to invoke hdiutil.' unless $?.exitstatus == 0
+      raise Informative, 'Failed to invoke hdiutil.' unless $?.exitstatus == 0
       result
     end
   end
@@ -337,7 +337,7 @@ HELP
       prepare_package unless pkg_path.exist?
       puts "Please authenticate to install #{name}..."
       `sudo installer -pkg #{pkg_path} -target /`
-      fail Informative, "Could not install #{name}, please try again" unless installed?
+      raise Informative, "Could not install #{name}, please try again" unless installed?
       source_receipts_dir = '/private/var/db/receipts'
       target_receipts_dir = "#{@install_prefix}/System/Library/Receipts"
       FileUtils.mkdir_p(target_receipts_dir)

--- a/lib/xcode/install/cli.rb
+++ b/lib/xcode/install/cli.rb
@@ -5,7 +5,7 @@ module XcodeInstall
       self.summary = 'Installs Xcode Command Line Tools.'
 
       def run
-        fail Informative, 'Xcode CLI Tools are already installed.' if installed?
+        raise Informative, 'Xcode CLI Tools are already installed.' if installed?
         install
       end
 

--- a/lib/xcode/install/install.rb
+++ b/lib/xcode/install/install.rb
@@ -35,9 +35,9 @@ module XcodeInstall
         super
 
         help! 'A VERSION argument is required.' unless @version
-        fail Informative, "Version #{@version} already installed." if @installer.installed?(@version) && !@force
-        fail Informative, "Version #{@version} doesn't exist." unless @installer.exist?(@version)
-        fail Informative, "Invalid URL: `#{@url}`" unless !@url || @url =~ /\A#{URI.regexp}\z/
+        raise Informative, "Version #{@version} already installed." if @installer.installed?(@version) && !@force
+        raise Informative, "Version #{@version} doesn't exist." unless @installer.exist?(@version)
+        raise Informative, "Invalid URL: `#{@url}`" unless !@url || @url =~ /\A#{URI.regexp}\z/
       end
 
       def run

--- a/lib/xcode/install/select.rb
+++ b/lib/xcode/install/select.rb
@@ -17,8 +17,8 @@ module XcodeInstall
       def validate!
         super
 
-        fail Informative, 'Please specify a version to select.' if @version.nil?
-        fail Informative, "Version #{@version} not installed." unless @installer.installed?(@version)
+        raise Informative, 'Please specify a version to select.' if @version.nil?
+        raise Informative, "Version #{@version} not installed." unless @installer.installed?(@version)
       end
 
       def run

--- a/lib/xcode/install/simulators.rb
+++ b/lib/xcode/install/simulators.rb
@@ -34,7 +34,7 @@ module XcodeInstall
         exit 1
       when 1
         simulator = filtered_simulators.first
-        fail Informative, "#{simulator.name} is already installed." if simulator.installed?
+        raise Informative, "#{simulator.name} is already installed." if simulator.installed?
         puts "Installing #{simulator.name} for Xcode #{simulator.xcode.bundle_version}..."
         simulator.install
       else

--- a/lib/xcode/install/uninstall.rb
+++ b/lib/xcode/install/uninstall.rb
@@ -16,7 +16,7 @@ module XcodeInstall
 
       def validate!
         super
-        fail Informative, "Version #{@version} is not installed." unless @installer.installed?(@version)
+        raise Informative, "Version #{@version} is not installed." unless @installer.installed?(@version)
       end
 
       def run

--- a/lib/xcode/install/version.rb
+++ b/lib/xcode/install/version.rb
@@ -1,3 +1,3 @@
 module XcodeInstall
-  VERSION = '1.2.5'
+  VERSION = '1.2.5'.freeze
 end


### PR DESCRIPTION
If we're specifying an internal URL where the .dmg is located, we shouldn't have anything to do with Apple authentication or credentials_manager.