### PR TITLE
Show help to invoke uninstall without VERSION

### DIFF
--- a/lib/xcode/install/uninstall.rb
+++ b/lib/xcode/install/uninstall.rb
@@ -16,6 +16,8 @@ module XcodeInstall
 
       def validate!
         super
+        help! 'A VERSION argument is required.' unless @version
+
         raise Informative, "Version #{@version} is not installed." unless @installer.installed?(@version)
       end
 

--- a/spec/uninstall_spec.rb
+++ b/spec/uninstall_spec.rb
@@ -1,0 +1,12 @@
+require File.expand_path('../spec_helper', __FILE__)
+
+module XcodeInstall
+  describe Command::Uninstall do
+    describe 'when invoked' do
+      it 'raise error when the version is not specified' do
+        Command::Uninstall.any_instance.expects(:help!)
+        -> { Command::Uninstall.run([]) }.should.raise(Exception)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently, we invoke `uninstall` command without any arguments. then following error is shown.

```sh
$ xcversion uninstall
[!] Version  is not installed.
```

This PR make it to show the help message in this situation.

```
$ xcversion uninstall
[!] A VERSION argument is required.

Usage:

    $ xcversion uninstall VERSION

      Uninstall a specific version of Xcode.

Options:

    --verbose   Show more debugging information
    --no-ansi   Show output without ANSI codes
    --help      Show help banner of specified command
```