### PR TITLE
Add option for showing DVTPlugInCompatibilityUUID

### DIFF
--- a/lib/xcode/install/installed.rb
+++ b/lib/xcode/install/installed.rb
@@ -4,10 +4,19 @@ module XcodeInstall
       self.command = 'installed'
       self.summary = 'List installed Xcodes.'
 
+      def self.options
+        [['--uuid', 'Show DVTPlugInCompatibilityUUID of plist.']].concat(super)
+      end
+
+      def initialize(argv)
+        @uuid = argv.flag?('uuid', false)
+        super
+      end
+
       def run
         installer = XcodeInstall::Installer.new
         installer.installed_versions.each do |xcode|
-          puts "#{xcode.version}\t(#{xcode.path})"
+          puts "#{xcode.version}\t(#{xcode.path})\t#{@uuid ? xcode.uuid : ''}"
         end
       end
     end


### PR DESCRIPTION
I made Xcode Plugin.
At the time of Xcode version up,  I must add the `DVTPlugInCompatibilityUUID` of new Xcode.
I want to see in the list the `DVTPlugInCompatibilityUUID`.
so I add new option `--uuid`.

```
$ xcversion installed
6.4	    (/Applications/Xcode-6.4.app)
7.2.1   (/Applications/Xcode-7.2.1.app)
7.3	    (/Applications/Xcode-7.3.app)
7.3.1   (/Applications/Xcode-7.3.1.app)

$ xcversion installed --uuid
6.4	    (/Applications/Xcode-6.4.app)     7FDF5C7A-131F-4ABB-9EDC-8C5F8F0B8A90
7.2.1   (/Applications/Xcode-7.2.1.app)   F41BD31E-2683-44B8-AE7F-5F09E919790E
7.3	    (/Applications/Xcode-7.3.app)     ACA8656B-FEA8-4B6D-8E4A-93F4C95C362C
7.3.1   (/Applications/Xcode-7.3.1.app)   ACA8656B-FEA8-4B6D-8E4A-93F4C95C362C
```