### PR TITLE
Extract the full beta version, add prerelease spec for 20160705

### DIFF
--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -280,7 +280,7 @@ HELP
       links = links.map { |pre| Xcode.new_prerelease(pre[1].strip.gsub(/.*Xcode /, ''), pre[0], pre[2]) }
 
       if links.count == 0
-        version = body.scan(/Xcode.* beta/).last.sub(/<.*?>/, '').gsub(/.*Xcode /, '')
+        version = body.scan(/Xcode.* beta.*<\/p>/).last.gsub(/<.*?>/, '').gsub(/.*Xcode /, '')
         link = body.scan(%r{<button .*"(.+?.xip)".*</button>}).first.first
         notes = body.scan(%r{<a.+?href="(/go/\?id=xcode-.+?)".*>(.*)</a>}).first.first
         links << Xcode.new(version, link, notes)

--- a/lib/xcode/install.rb
+++ b/lib/xcode/install.rb
@@ -280,7 +280,7 @@ HELP
       links = links.map { |pre| Xcode.new_prerelease(pre[1].strip.gsub(/.*Xcode /, ''), pre[0], pre[2]) }
 
       if links.count == 0
-        version = body.scan(/Xcode.* beta.*<\/p>/).last.gsub(/<.*?>/, '').gsub(/.*Xcode /, '')
+        version = body.scan(%r{Xcode.* beta.*<\/p>}).last.gsub(/<.*?>/, '').gsub(/.*Xcode /, '')
         link = body.scan(%r{<button .*"(.+?.xip)".*</button>}).first.first
         notes = body.scan(%r{<a.+?href="(/go/\?id=xcode-.+?)".*>(.*)</a>}).first.first
         links << Xcode.new(version, link, notes)

--- a/spec/fixtures/devcenter/xcode-20160705.html
+++ b/spec/fixtures/devcenter/xcode-20160705.html
@@ -1,0 +1,1909 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<meta name="Author" content="Apple Inc." />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7, IE=9">
+<link rel="shortcut icon" href="/favicon.ico" />
+<link rel="icon" href="/favicon.ico" />
+<link rel="mask-icon" href="/apple-logo.svg" color="#333333">
+
+<link rel="stylesheet" href="/assets/styles/globalnav.css" type="text/css" />
+<link rel="stylesheet" href="/assets/styles/global.css" type="text/css" />
+
+<script src="https://devimages.apple.com.edgekey.net/assets/scripts/lib/jquery/jquery-1.11.0.min.js"></script>
+<script src="https://devimages.apple.com.edgekey.net/assets/scripts/lib/jquery/jquery.retinate.js" type="text/javascript" charset="utf-8"></script>
+<!--[if lt IE 9]>
+	<link rel="stylesheet" href="/assets/styles/oldie.css" type="text/css" />
+	<script src="/assets/scripts/html5.js"></script>
+<![endif]-->
+<script src="/assets/scripts/lg-search.js"></script>
+<script src="/assets/scripts/global.js"></script>
+
+	<link rel="stylesheet" href="https://www.apple.com/wss/fonts?family=Myriad+Set+Pro&v=2" type="text/css" />
+
+	<title>Download - Apple Developer</title>
+	<meta name="omni_page" content="Download - Apple Developer">
+	<link rel="stylesheet" href="/download/styles/download.css" type="text/css" />
+
+					<script type="text/javascript">
+			(function(window, undefined) {
+				window.userIsMemberOfProgram = true;
+			}(window));
+		</script>	
+			<script type="text/javascript" src="/download/scripts/download.js"></script>
+	
+</head>
+<body>
+	<input type="checkbox" id="ac-gn-menustate" class="ac-gn-menustate">
+<nav id="ac-globalnav" class="no-js" role="navigation" aria-label="Global Navigation" data-hires="false" data-analytics-region="global nav" lang="en-US">
+	<div class="ac-gn-content">
+		<ul class="ac-gn-header">
+			<li class="ac-gn-item ac-gn-menuicon"> <label class="ac-gn-menuicon-label" for="ac-gn-menustate" aria-hidden="true">
+					<span class="ac-gn-menuicon-bread ac-gn-menuicon-bread-top">
+						<span class="ac-gn-menuicon-bread-crust ac-gn-menuicon-bread-crust-top"></span>
+					</span>
+					<span class="ac-gn-menuicon-bread ac-gn-menuicon-bread-bottom">
+						<span class="ac-gn-menuicon-bread-crust ac-gn-menuicon-bread-crust-bottom"></span>
+					</span>
+				</label>
+				<a href="#ac-gn-menustate" class="ac-gn-menuanchor ac-gn-menuanchor-open" id="ac-gn-menuanchor-open"> <span class="ac-gn-menuanchor-label">Open Menu</span> </a>
+				<a href="#" class="ac-gn-menuanchor ac-gn-menuanchor-close" id="ac-gn-menuanchor-close"> <span class="ac-gn-menuanchor-label">Close Menu</span> </a>
+			</li>
+			<li class="ac-gn-item ac-gn-apple">
+				<a class="ac-gn-link ac-gn-link-apple" href="/" id="ac-gn-firstfocus-small"> <span class="ac-gn-link-text">Apple Developer</span> </a>
+			</li>
+			<li class="ac-gn-item ac-gn-bag ac-gn-bag-small" id="ac-gn-bag-small">
+				<a class="ac-gn-link ac-gn-link-bag" href="/account/"> <span class="ac-gn-link-text">Account</span> <span class="ac-gn-bag-badge"></span> </a> <span class="ac-gn-bagview-caret ac-gn-bagview-caret-large"></span> </li>
+		</ul>
+		<ul class="ac-gn-list">
+			<li class="ac-gn-item ac-gn-apple">
+				<a class="ac-gn-link ac-gn-link-apple" href="/" id="ac-gn-firstfocus"> <span class="ac-gn-link-text">Apple Developer</span> </a>
+			</li>
+			<li class="ac-gn-item ac-gn-item-menu ac-gn-discover">
+				<a class="ac-gn-link" href="/discover/"> <span>Discover</span> </a>
+			</li>
+			<li class="ac-gn-item ac-gn-item-menu ac-gn-design">
+				<a class="ac-gn-link" href="/design/"> <span>Design</span> </a>
+			</li>
+			<li class="ac-gn-item ac-gn-item-menu ac-gn-develop">
+				<a class="ac-gn-link" href="/develop/"> <span>Develop</span> </a>
+			</li>
+			<li class="ac-gn-item ac-gn-item-menu ac-gn-distribute">
+				<a class="ac-gn-link" href="/distribute/"> <span>Distribute</span> </a>
+			</li>
+			<li class="ac-gn-item ac-gn-item-menu ac-gn-support">
+				<a class="ac-gn-link" href="/support/"> <span>Support</span> </a>
+			</li>
+			<li class="ac-gn-item ac-gn-item-menu ac-gn-account">
+				<a class="ac-gn-link" href="/account/"> <span>Account</span> </a>
+			</li>
+			<li class="ac-gn-item ac-gn-item-menu ac-gn-search" role="search">
+				<a id="ac-gn-search-button" class="ac-gn-link ac-gn-link-search" href="/search/" aria-label="Search developer.apple.com"> <span class="ac-gn-search-placeholder" aria-hidden="true">Search</span> </a>
+			</li>
+		</ul>
+		<aside id="ac-gn-searchview" class="ac-gn-searchview" role="search" data-analytics-region="search">
+			<div class="ac-gn-searchview-content">
+				<form id="ac-gn-searchform" class="ac-gn-searchform" action="/search/" method="get">
+					<div class="ac-gn-searchform-wrapper"> <input id="ac-gn-searchform-input" class="ac-gn-searchform-input" type="text" name="q" placeholder="Search" data-placeholder-long="Search for documentation, videos, and more" autocorrect="off" autocapitalize="off" autocomplete="off" spellcheck="false" /> <button id="ac-gn-searchform-submit" class="ac-gn-searchform-submit" type="submit" disabled aria-label="Submit"></button> <button id="ac-gn-searchform-reset" class="ac-gn-searchform-reset" type="reset" disabled aria-label="Clear Search"></button> </div>
+				</form>
+				<aside id="ac-gn-searchresults" class="ac-gn-searchresults" data-string-quicklinks="Quick Links" data-string-suggestions="Suggested Searches" data-string-noresults="Hit enter to search.">
+
+				</aside>
+			</div> <button id="ac-gn-searchview-close" class="ac-gn-searchview-close" aria-label="Close Search">
+					<span class="ac-gn-searchview-close-wrapper">
+						<span class="ac-gn-searchview-close-left"></span>
+						<span class="ac-gn-searchview-close-right"></span>
+					</span>
+				</button> </aside>
+	</div>
+</nav>
+<div id="ac-gn-curtain" class="ac-gn-curtain"></div>
+<div id="ac-gn-placeholder" class="ac-nav-placeholder"></div>
+<script type="text/javascript" src="/assets/scripts/ac-globalnav.built.js"></script>
+
+	<div id="top">
+<!-- SiteCatalyst code version: H.8. Copyright 1997-2006 Omniture, Inc. -->
+<script type="text/javascript">
+/* RSID: */
+var s_account="appleglobal,appleusdeveloper"
+</script>
+
+<script type="text/javascript" src="https://www.apple.com/metrics/scripts/s_code_h.js"></script>
+<script type="text/javascript">
+s.pageName= AC && AC.Tracking && AC.Tracking.pageName();
+s.channel="www.us.developer"
+
+/************* DO NOT ALTER ANYTHING BELOW THIS LINE ! **************/
+var s_code=s.t();if(s_code)document.write(s_code)</script>
+<!-- End SiteCatalyst code version: H.8. -->
+</div>
+
+	<main id="main" class="main" role="main">
+
+		<section class="grid">
+			<section class="row">
+				<section class="col-100">
+										<nav class="logout-bar">
+						<ul>
+							<li>Timothy Sutton</li>
+							<li> | </li>
+							<li><a href="/logout/?return=%2Fios%2Fdownload%2Fwwdc%2F" class="sign-out">Sign out</a></li>
+						</ul>
+					</nav>
+										<h1 class="text-center">Downloads</h1>
+					<p class=" text-center center width-75 intro">Get the latest beta releases of Xcode, iOS, macOS, watchOS, tvOS, and more.</p>
+				</section>
+			</section>
+		</section>
+
+						<section class="grid">
+				<div class="row">
+					<div class="col-100">
+				<!-- FEATURED TABLE -->
+						<section class="warning" data-hires-status="pending">
+							<p class="smaller"><strong>Important:</strong> You must have the latest beta version of Xcode 8 installed on your Mac before using a Restore Image to install iOS or tvOS beta software on a device.</p>
+						</section>
+
+						<p class="footnote">Your use of Apple beta software is subject to and licensed only under the terms and conditions of the Apple Developer Program License Agreement, including any applicable consent to collect diagnostic data set forth therein. If you have not agreed to the Apple Developer Program License Agreement, you are not permitted to use this software. Refer to the software installation guides for complete instructions.</p>
+					</div>
+				</div>
+				<div class="row">
+					<section class="table">
+						<section class="table-top-sticky">
+							<section class="table-header">
+								<section class="col-60">
+
+									<!-- Table title -->
+									<span>Featured Downloads</span>
+
+								</section>
+								<section class="col-40">
+								<ul class="download-details">
+									<li class="release-notes">&nbsp;</li>
+									<li class="build-number">Build</li>
+									<li class="published-date">Date</li>
+									<li class="download">&nbsp;</li>
+								</ul>
+							</section>
+							</section>
+						</section>
+
+						<ul class="table-rows">
+
+							<!-- Xcode 8 BETA -->
+							<li class="table-row">
+								<section class="col-60">
+									<p><span class="platform-title">Xcode</span> 8 beta 2</p>
+									<p class="smaller">Includes the SDKs for iOS 10 beta, macOS 10.12 beta, watchOS 3 beta, and tvOS 10 beta.</p>
+								</section>
+								<section class="col-40">
+									<ul class="download-details">
+										<li class="release-notes"><a href="/go/?id=xcode-8-beta-rn">Release Notes</a></li>
+										<li class="build-number">8S162m</li>
+										<li class="published-date">Jul 5, 2016</li>
+										<li class="download"><button class="direct-download" value="/services-account/download?path=/Developer_Tools/Xcode_8_beta_2/Xcode_8_beta_2.xip">Download</button></li>
+									</ul>
+								</section>
+							</li>
+
+							<!-- macOS BETA -->
+							<li class="table-row">
+								<section class="col-60">
+									<p><span class="platform-title">macOS</span> 10.12 beta 2</p>
+									<p class="smaller">Refer to the release notes for complete installation instructions.</p>
+									<p class="smaller hidden">App Store Redemption Code: <span data-promo-id="FJ16HYT13M"></span></p>
+								</section>
+								<section class="col-40">
+									<ul class="download-details">
+										<li class="release-notes"><a href="/go/?id=macos-10.12-beta-rn">Release Notes</a></li>
+										<li class="build-number">16A239j</li>
+										<li class="published-date">Jul 5, 2016</li>
+										<li class="download"><button data-promo-id="FJ16HYT13M">Download</button></li>
+									</ul>
+								</section>
+							</li>
+
+							<!-- iOS BETA -->
+							<li class="table-row">
+								<section class="col-60">
+									<p><span class="platform-title">iOS</span> 10 beta 2</p>
+									<p class="smaller">Configuration Profile and Restore Images.</p>
+								</section>
+								<section class="col-40">
+									<ul class="download-details">
+										<li class="release-notes"><a href="/go/?id=ios-10.0-sdk-rn">Release Notes</a></li>
+										<li class="build-number">14A5297c</li>
+										<li class="published-date">Jul 5, 2016</li>
+										<li class="download"><button class="drop-down">Open</button></li>
+									</ul>
+								</section>
+
+								<!-- iOS DOWNLOADS -->
+								<ul class="sub-list col-100">
+									<li class="table-row">
+										<section class="col-60">
+											<p>Configuration Profile <span class="violator violator-inline violator-alt">Preferred</span></p>
+											<p class="smaller">Install directly on any iOS device and receive OTA updates.</p>
+										</section>
+										<section class="col-40">
+											<ul class="download-details">
+												<li class="download"><button class="direct-download" value="/services-account/download?path=/WWDC_2016/iOS_10_beta/iOS_10_beta_Configuration_Profile.mobileconfig">Download</button></li>
+											</ul>
+										</section>
+									</li>
+									<li class="table-row">
+										<section class="col-60">
+											<p>iPhone SE</p>
+											<p class="smaller">Restore image for listed devices.</p>
+										</section>
+										<section class="col-40">
+											<ul class="download-details">
+												<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.0/031-64063-20160705-9D3BDF9E-3FC2-11E6-A2B6-ACB8C1708330/iPhoneSE_10.0_14A5297c_Restore.ipsw">Download</button></li>
+											</ul>
+										</section>
+									</li>
+									<li class="table-row">
+										<section class="col-60">
+											<p>iPhone 6s, iPhone 6</p>
+											<p class="smaller">Restore image for listed devices.</p>
+										</section>
+										<section class="col-40">
+											<ul class="download-details">
+												<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.0/031-64028-20160705-9D39240C-3FC2-11E6-A398-9EB8C1708330/iPhone_4.7_10.0_14A5297c_Restore.ipsw">Download</button></li>
+											</ul>
+										</section>
+									</li>
+									<li class="table-row">
+										<section class="col-60">
+											<p>iPhone 6s Plus, iPhone 6 Plus</p>
+											<p class="smaller">Restore image for listed devices.</p>
+										</section>
+										<section class="col-40">
+											<ul class="download-details">
+												<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.0/031-64060-20160705-9D3A9044-3FC2-11E6-A37B-ABB8C1708330/iPhone_5.5_10.0_14A5297c_Restore.ipsw">Download</button></li>
+											</ul>
+										</section>
+									</li>
+									<li class="table-row">
+										<section class="col-60">
+											<p>iPhone 5s</p>
+											<p class="smaller">Restore image for listed devices.</p>
+										</section>
+										<section class="col-40">
+											<ul class="download-details">
+												<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.0/031-64058-20160705-9D39D21C-3FC2-11E6-BB2B-AAB8C1708330/iPhone_4.0_64bit_10.0_14A5297c_Restore.ipsw">Download</button></li>
+											</ul>
+										</section>
+									</li>
+									<li class="table-row">
+										<section class="col-60">
+											<p>iPhone 5c, iPhone 5</p>
+											<p class="smaller">Restore image for listed devices.</p>
+										</section>
+										<section class="col-40">
+											<ul class="download-details">
+												<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.0/031-64051-20160705-9D3A77DA-3FC2-11E6-BA2C-A9B8C1708330/iPhone_4.0_32bit_10.0_14A5297c_Restore.ipsw">Download</button></li>
+											</ul>
+										</section>
+									</li>
+									<li class="table-row">
+										<section class="col-60">
+											<p>9.7‑inch iPad Pro</p>
+											<p class="smaller">Restore image for listed devices.</p>
+										</section>
+										<section class="col-40">
+											<ul class="download-details">
+												<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.0/031-64039-20160705-9D39C3D0-3FC2-11E6-81C7-A6B8C1708330/iPadPro_9.7_10.0_14A5297c_Restore.ipsw">Download</button></li>
+											</ul>
+										</section>
+									</li>
+									<li class="table-row">
+										<section class="col-60">
+											<p>12.9‑inch iPad Pro</p>
+											<p class="smaller">Restore image for listed devices.</p>
+										</section>
+										<section class="col-40">
+											<ul class="download-details">
+												<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.0/031-64033-20160705-9D39A300-3FC2-11E6-9A1F-A2B8C1708330/iPadPro_12.9_10.0_14A5297c_Restore.ipsw">Download</button></li>
+											</ul>
+										</section>
+									</li>
+									<li class="table-row">
+										<section class="col-60">
+											<p>iPad mini 4, iPad Air 2, iPad mini 3</p>
+											<p class="smaller">Restore image for listed devices.</p>
+										</section>
+										<section class="col-40">
+											<ul class="download-details">
+												<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.0/031-64038-20160705-9D39C7FE-3FC2-11E6-BE79-A4B8C1708330/iPad_64bit_TouchID_10.0_14A5297c_Restore.ipsw">Download</button></li>
+											</ul>
+										</section>
+									</li>
+									<li class="table-row">
+										<section class="col-60">
+											<p>iPad Air, iPad mini 2</p>
+											<p class="smaller">Restore image for listed devices.</p>
+										</section>
+										<section class="col-40">
+											<ul class="download-details">
+												<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.0/031-64024-20160705-9D387728-3FC2-11E6-8DAC-8FB6C1708330/iPad_64bit_10.0_14A5297c_Restore.ipsw">Download</button></li>
+											</ul>
+										</section>
+									</li>
+									<li class="table-row">
+										<section class="col-60">
+											<p>iPad <span class="lighter">(4th generation Model)</span></p>
+											<p class="smaller">Restore image for listed devices.</p>
+										</section>
+										<section class="col-40">
+											<ul class="download-details">
+												<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.0/031-64040-20160705-9D391B2E-3FC2-11E6-A88D-A7B8C1708330/iPad_32bit_10.0_14A5297c_Restore.ipsw">Download</button></li>
+											</ul>
+										</section>
+									</li>	
+									<li class="table-row">
+										<section class="col-60">
+											<p>iPod touch <span class="lighter">(6th generation)</span></p>
+											<p class="smaller">Restore image for listed devices.</p>
+										</section>
+										<section class="col-40">
+											<ul class="download-details">
+												<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios10.0/031-64029-20160705-9D388A7E-3FC2-11E6-BA49-A0B8C1708330/iPodtouch_10.0_14A5297c_Restore.ipsw">Download</button></li>
+											</ul>
+										</section>
+									</li>
+								</ul>
+							</li>
+
+							<!-- watchOS BETA -->
+							<li class="table-row">
+								<section class="col-60">
+									<p><span class="platform-title">watchOS</span> 3 beta 2</p>
+									<p class="smaller">Install configuration profile directly on your device to receive OTA updates.</p>
+								</section>
+								<section class="col-40">
+									<ul class="download-details">
+										<li class="release-notes"><a href="/go/?id=watchos-3.0-sdk-rn">Release Notes</a></li>
+										<li class="build-number">14S5278d</li>
+										<li class="published-date">Jul 5, 2016</li>
+										<li class="download"><button class="direct-download" value="/services-account/download?path=/WWDC_2016/watchOS_3_beta/watchOS_3_beta_Configuration_Profile.mobileconfig">Download</button></li>
+									</ul>
+								</section>
+							</li>
+
+							<!-- tvOS BETA -->
+							<li class="table-row">
+								<section class="col-60">
+									<p><span class="platform-title">tvOS</span> 10 beta 2</p>
+									<p class="smaller">For Apple TV (4th generation). Apple TV (3rd generation) and earlier are not supported.</p>
+								</section>
+								<section class="col-40">
+									<ul class="download-details">
+										<li class="release-notes"><a href="/go/?id=tvos-10.0-sdk-rn">Release Notes</a></li>
+										<li class="build-number">14T5284d</li>
+										<li class="published-date">Jul 5, 2016</li>
+										<li class="download"><button class="drop-down">Open</button></li>
+									</ul>
+								</section>
+
+								<!-- tvOS DOWNLOADS -->
+								<ul class="sub-list col-100">
+									<li class="table-row">
+										<section class="col-60">
+											<p>Configuration Profile <span class="violator violator-inline violator-alt">Preferred</span></p>
+											<p class="smaller">Install configuration profile directly on your device to receive OTA updates.</p>
+										</section>
+										<section class="col-40">
+											<ul class="download-details">
+												<li class="download"><button class="direct-download" value="/services-account/download?path=/WWDC_2016/tvOS_10_beta/tvOS_10_beta_Configuration_Profile.mobileconfig">Download</button></li>
+											</ul>
+										</section>
+									</li>
+									<li class="table-row">
+										<section class="col-60">
+											<p>Restore Image</p>
+											<p class="smaller">Install via iTunes.</p>
+										</section>
+										<section class="col-40">
+											<ul class="download-details">
+												<li class="download"><button class="direct-download" value="http://appldnld.apple.com/tvosseeds/031-66743-20160705-69582DAC-3FA6-11E6-BAED-E47760941A1E/AppleTV5,3_10.0_14T5284d_Restore.ipsw">Download</button></li>
+											</ul>
+										</section>
+									</li>
+								</ul>
+							</li>
+
+							<!-- Server BETA -->
+							<li class="table-row">
+								<section class="col-60">
+									<p><span class="platform-title">Server</span> 5.2 beta</p>
+								</section>
+								<section class="col-40">
+									<ul class="download-details">
+										<li class="release-notes"><a href="/go/?id=server-5.2-beta-rn">Release Notes</a></li>
+										<li class="build-number">16S1083q</li>
+										<li class="published-date">Jun 13, 2016</li>
+										<li class="download"><button class="direct-download" value="/services-account/download?path=/WWDC_2016/Server_5.2_beta/Server_5.2_beta.dmg">Download</button></li>
+									</ul>
+								</section>
+							</li>
+
+							<!-- Configurator BETA -->
+							<li class="table-row">
+								<section class="col-60">
+									<p><span class="platform-title">Apple Configurator</span> 2.3 beta 2</p>
+									<p class="smaller">Mac app for deploying iOS devices and Apple TV in your school or business.</p>
+								</section>
+								<section class="col-40">
+									<ul class="download-details">
+										<li class="release-notes"><a href="/go/?id=apple-configurator-2.3-beta-rn">Release Notes</a></li>
+										<li class="build-number">3D27</li>
+										<li class="published-date">Jul 5, 2016</li>
+										<li class="download"><button class="drop-down">Open</button></li>
+									</ul>
+								</section>
+
+								<!-- Configurator DOWNLOADS -->
+								<ul class="sub-list col-100">
+									<li class="table-row">
+										<section class="col-60">
+											<p>MobileDevice Installer <span class="violator violator-inline violator-alt">Required</span></p>
+											<p class="smaller">Install the latest MobileDevice installer before using Apple Configurator 2.3 beta.</p>
+										</section>
+										<section class="col-40">
+											<ul class="download-details">
+												<li class="download"><button class="direct-download" value="/services-account/download?path=/iOS/Apple_Configurator_2.3_beta_2/MobileDevice.dmg">Download</button></li>
+											</ul>
+										</section>
+									</li>
+									<li class="table-row">
+										<section class="col-60">
+											<p>Apple Configurator 2.3 beta 2</p>
+										</section>
+										<section class="col-40">
+											<ul class="download-details">
+												<li class="download"><button class="direct-download" value="/services-account/download?path=/iOS/Apple_Configurator_2.3_beta_2/Apple_Configurator_2.3_beta_2.dmg">Download</button></li>
+											</ul>
+										</section>
+									</li>
+								</ul>
+							</li>
+
+							<!-- Remote BETA -->
+							<li class="table-row">
+								<section class="col-60">
+									<p><span class="platform-title">Apple TV Remote</span> 1.0 beta 2</p>
+									<p class="smaller">Use Xcode or iTunes to install iOS app to device.</p>
+								</section>
+								<section class="col-40">
+									<ul class="download-details">
+										<li class="release-notes"><a href="/go/?id=apple-tv-remote-1.0-beta-rn">Release Notes</a></li>
+										<li class="build-number">1A135</li>
+										<li class="published-date">Jul 5, 2016</li>
+										<li class="download"><button class="direct-download" value="/services-account/download?path=/Applications/Apple_TV_Remote_1.0_beta_2/Apple_TV_Remote_1.0_beta_2.dmg">Download</button></li>
+									</ul>
+								</section>
+							</li>
+
+						</ul>
+					</section>
+				</div>
+			<!-- BETA TABLE -->
+			<div class="row">
+				<section class="table">
+					<section class="table-top-sticky">
+						<section class="table-header">
+							<section class="col-60">
+
+								<!-- Table title -->
+								<span>Beta Software</span>
+
+							</section>
+							<section class="col-40">
+							<ul class="download-details">
+								<li class="release-notes">&nbsp;</li>
+								<li class="build-number">Build</li>
+								<li class="published-date">Date</li>
+								<li class="download">&nbsp;</li>
+							</ul>
+						</section>
+						</section>
+					</section>
+
+					<ul class="table-rows">
+
+						<!-- OS X BETA -->
+						<li class="table-row">
+							<section class="col-60">
+								<p><span class="platform-title">OS X</span> 10.11.6 beta 4</p>
+							</section>
+							<section class="col-40">
+								<ul class="download-details">
+									<li class="release-notes"><a href="/go/?id=os-x-10.11.6-rn">Release Notes</a></li>
+									<li class="build-number">15G24b</li>
+									<li class="published-date">Jun 29, 2016</li>
+									<li class="download"><button class="direct-download" value="/services-account/download?path=/OS_X/OS_X_Seed_Configuration_Utility/OS_X_Software_Update_Seed_Configuration_Utility.dmg">Download</button></li>
+								</ul>
+							</section>
+						</li>
+						
+						<!-- iOS -->
+						<li class="table-row">
+							<section class="col-60">
+								<p><span class="platform-title">iOS</span> 9.3.3 beta 4</p>
+								<p class="smaller">Restore Images</p>
+							</section>
+							<section class="col-40">
+								<ul class="download-details">
+									<li class="release-notes"><a href="/go/?id=ios-9.3.3-sdk-rn">Release Notes</a></li>
+									<li class="build-number">13G33</li>
+									<li class="published-date">Jun 29, 2016</li>
+									<li class="download"><button class="drop-down">Open</button></li>
+								</ul>
+							</section>
+
+							<!-- iOS DOWNLOADS -->
+							<ul class="sub-list col-100">
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPhone SE</p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64760-20160629-A1EB3082-3CBE-11E6-BC26-99EEC2777EA3/iPhone8,4_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPhone 6s</p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64789-20160629-0BDB8194-3CC0-11E6-9908-36F4C2777EA3/iPhone8,1_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPhone 6s Plus</p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64699-20160629-A1DD5C0A-3CBE-11E6-9F59-81EEC2777EA3/iPhone8,2_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPhone 6</p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download"  value="http://appldnld.apple.com/iOS9.3.3Seed/031-64746-20160629-A1E5CCA0-3CBE-11E6-B8D5-96EEC2777EA3/iPhone7,2_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPhone 6 Plus</p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64701-20160629-A1DE36CA-3CBE-11E6-BDBF-83EEC2777EA3/iPhone7,1_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPhone 5s <span class="lighter">(Model A1453, A1533)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64709-20160629-A1E8EBEC-3CBE-11E6-B6DD-87EEC2777EA3/iPhone6,1_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPhone 5s <span class="lighter">(Model A1457, A1518, A1528, A1530)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64787-20160629-EBB5C6F4-3CBF-11E6-884D-B9F3C2777EA3/iPhone6,2_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPhone 5c <span class="lighter">(Model A1456, A1532)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64837-20160629-CD9153C2-3CC0-11E6-AD95-F6F5C2777EA3/iPhone5,3_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPhone 5c <span class="lighter">(Model A1507, A1516, A1526, A1529)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64812-20160629-83A39CF2-3CC0-11E6-9B87-51F5C2777EA3/iPhone5,4_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPhone 5 <span class="lighter">(Model A1428)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64721-20160629-A1F06084-3CBE-11E6-94F2-91EEC2777EA3/iPhone5,1_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPhone 5 <span class="lighter">(Model A1429)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64705-20160629-A1DE9AC0-3CBE-11E6-BE30-85EEC2777EA3/iPhone5,2_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPhone 4s</p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64813-20160629-A6583C9E-3CC0-11E6-9534-99F5C2777EA3/iPhone4,1_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPod touch <span class="lighter">(5th generation)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64682-20160629-A1D58944-3CBE-11E6-B40C-73EEC2777EA3/iPod5,1_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPod touch <span class="lighter">(6th generation)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64779-20160629-B24642F4-3CBF-11E6-A3CD-C6F2C2777EA3/iPod7,1_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>9.7-inch iPad Pro <span class="lighter">(Wi-Fi)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64802-20160629-1F67AC38-3CC0-11E6-9DDE-BFF4C2777EA3/iPad6,3_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>9.7-inch iPad Pro <span class="lighter">(Wi-Fi + Cellular)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64759-20160629-A1F102AA-3CBE-11E6-B17A-98EEC2777EA3/iPad6,4_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>12.9-inch iPad Pro <span class="lighter">(Wi-Fi)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64686-20160629-A1DBB968-3CBE-11E6-81B8-79EEC2777EA3/iPad6,7_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>12.9-inch iPad Pro <span class="lighter">(Wi-Fi + Cellular)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64674-20160629-A1D4B438-3CBE-11E6-B81F-6FEEC2777EA3/iPad6,8_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad mini 4 <span class="lighter">(Wi-Fi)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64788-20160629-07560752-3CC0-11E6-A3C1-1CF4C2777EA3/iPad5,1_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad mini 4 <span class="lighter">(Wi-Fi + Cellular)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64683-20160629-A1D69424-3CBE-11E6-B1D7-75EEC2777EA3/iPad5,2_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad Air 2 <span class="lighter">(Model A1566)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64844-20160629-1FF56068-3CC1-11E6-9804-DEF6C2777EA3/iPad5,3_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad Air 2 <span class="lighter">(Model A1567)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64719-20160629-A1E7FE8A-3CBE-11E6-9181-8EEEC2777EA3/iPad5,4_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad mini 3 <span class="lighter">(Model A1599)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64693-20160629-A1D9669A-3CBE-11E6-830B-7CEEC2777EA3/iPad4,7_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad mini 3 <span class="lighter">(Model A1600)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64804-20160629-3448AD1E-3CC0-11E6-B4A1-ECF4C2777EA3/iPad4,8_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad mini 3 <span class="lighter">(Model A1601)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64669-20160629-A1D69F50-3CBE-11E6-AE89-6DEEC2777EA3/iPad4,9_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad Air <span class="lighter">(Model A1474)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64736-20160629-A1E62132-3CBE-11E6-A402-93EEC2777EA3/iPad4,1_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad Air <span class="lighter">(Model A1475)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64770-20160629-95DF1A0A-3CBF-11E6-B32F-53F2C2777EA3/iPad4,2_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad Air <span class="lighter">(Model A1476)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64685-20160629-A1DA9E8E-3CBE-11E6-A389-77EEC2777EA3/iPad4,3_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad mini 2 <span class="lighter">(Model A1489)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64679-20160629-A1D3B416-3CBE-11E6-B55F-71EEC2777EA3/iPad4,4_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad mini 2 <span class="lighter">(Model A1490)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64688-20160629-A1D8DB44-3CBE-11E6-9320-7BEEC2777EA3/iPad4,5_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad mini 2 <span class="lighter">(Model A1491)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64838-20160629-DD7A2CB4-3CC0-11E6-9056-41F6C2777EA3/iPad4,6_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad <span class="lighter">(4th generation Model A1458)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64814-20160629-CA216150-3CC0-11E6-B2F9-DAF5C2777EA3/iPad3,4_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad <span class="lighter">(4th generation Model A1459)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64716-20160629-A1F18F22-3CBE-11E6-A165-8DEEC2777EA3/iPad3,5_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad <span class="lighter">(4th generation Model A1460)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64792-20160629-15978D18-3CC0-11E6-8F15-8CF4C2777EA3/iPad3,6_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad mini<span class="lighter">(Model A1432)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64712-20160629-A1ED0CB8-3CBE-11E6-B785-88EEC2777EA3/iPad2,5_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad mini<span class="lighter">(Model A1454)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64748-20160629-A1EAE366-3CBE-11E6-A852-97EEC2777EA3/iPad2,6_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad mini<span class="lighter">(Model A1455)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64808-20160629-3BD2E5C2-3CC0-11E6-ACE0-22F5C2777EA3/iPad2,7_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad Wi-Fi <span class="lighter">(3rd generation)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64713-20160629-A1E84DEA-3CBE-11E6-8F35-8AEEC2777EA3/iPad3,1_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad Wi-Fi + Cellular <span class="lighter">(model for ATT)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64741-20160629-A1F1E3A0-3CBE-11E6-B392-95EEC2777EA3/iPad3,3_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad Wi-Fi + Cellular <span class="lighter">(model for Verizon)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64769-20160629-6A5B770C-3CBF-11E6-8909-17F2C2777EA3/iPad3,2_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad 2 Wi-Fi <span class="lighter">(Rev A)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64763-20160629-4E9B71D4-3CBF-11E6-9AAC-E6F1C2777EA3/iPad2,4_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad 2 Wi-Fi</p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64698-20160629-A1DAB90A-3CBE-11E6-97F8-7EEEC2777EA3/iPad2,1_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad 2 Wi-Fi + 3G <span class="lighter">(GSM)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64841-20160629-F7882D40-3CC0-11E6-8FDA-92F6C2777EA3/iPad2,2_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad 2 Wi-Fi + 3G <span class="lighter">(CDMA)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/iOS9.3.3Seed/031-64778-20160629-A2151E50-3CBF-11E6-870A-9BF2C2777EA3/iPad2,3_9.3.3_13G33_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+							</ul>
+
+						</li>
+
+						<!-- tvOS BETA -->
+						<li class="table-row">
+							<section class="col-60">
+								<p><span class="platform-title">tvOS</span> 9.2.2 beta 4</p>
+								<p class="smaller">Restore Image</p>
+							</section>
+							<section class="col-40">
+								<ul class="download-details">
+									<li class="release-notes"><a href="/go/?id=tvos-9.2.2-sdk-rn">Release Notes</a></li>
+									<li class="build-number">13Y824</li>
+									<li class="published-date">Jun 29, 2016</li>
+									<li class="download"><button class="drop-down">Open</button></li>
+								</ul>
+							</section>
+
+							<ul class="sub-list col-100">
+								<li class="table-row">
+									<section class="col-60">
+										<p>Restore Image</p>
+										<p class="smaller">Update via iTunes.</p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="/services-account/download?path=/tvOS/tvOS_9.2.2_beta_4/AppleTV53_9.2.2_13Y824_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+							</ul>
+						</li>
+
+						<!-- OS X Server BETA -->
+						<li class="table-row">
+							<section class="col-60">
+								<p><span class="platform-title">Server</span> 5.1.6 beta</p>
+							</section>
+							<section class="col-40">
+								<ul class="download-details">
+									<li class="release-notes"><a href="/services-account/download?path=/OS_X_Server/Server_5.1.6_beta/Server_5.1.6_beta_Release_Notes.pdf">Release Notes</a></li>
+									<li class="build-number">15S7053</li>
+									<li class="published-date">Jun 29, 2016</li>
+									<li class="download"><button class="direct-download" value="/services-account/download?path=/OS_X_Server/Server_5.1.6_beta/Server_5.1.6_beta.dmg">Download</button></li>
+								</ul>
+							</section>
+						</li>
+
+						<!-- Safari 10 BETA -->
+						<li class="table-row">
+							<section class="col-60">
+								<p><span class="platform-title">Safari</span> 10 beta 2</p>
+								<p class="smaller">Safari 10 beta 2 for OS X El Capitan and OS X Yosemite.</p>
+							</section>
+							<section class="col-40">
+								<ul class="download-details">
+									<li class="release-notes"><a href="/services-account/download?path=/Safari/Safari_10_for_OS_X_El_Capitan_and_Yosemite_beta_2/Safari_10_Beta_2_Notes.pdf">Release Notes</a></li>
+									<li class="build-number">11602.1.38.4</li>
+									<li class="published-date">Jul 5, 2016</li>
+									<li class="download"><button class="drop-down">Open</button></li>
+								</ul>
+							</section>
+
+							<!-- Safari 10 DOWNLOADS -->
+							<ul class="sub-list col-100">
+								<li class="table-row">
+									<section class="col-60">
+										<p>Safari 10 beta 2 for OS X El Capitan</p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="/services-account/download?path=/Safari/Safari_10_for_OS_X_El_Capitan_and_Yosemite_beta_2/Safari_10_for_OS_X_El_Capitan_beta_2.dmg">Download</button></li>
+										</ul>
+									</section>
+								</li>
+								<li class="table-row">
+									<section class="col-60">
+										<p>Safari 10 beta 2 for OS X Yosemite</p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="/services-account/download?path=/Safari/Safari_10_for_OS_X_El_Capitan_and_Yosemite_beta_2/Safari_10_for_OS_X_Yosemite_beta_2.dmg">Download</button></li>
+										</ul>
+									</section>
+								</li>
+							</ul>
+						</li>
+						
+						<!-- Parallax Exporter -->
+						<li class="table-row">
+							<section class="col-60">
+								<p>Parallax Exporter</p>
+								<p class="smaller">Use the Parallax Exporter plug-in to preview a layered image while working in Adobe Photoshop.</p>
+							</section>
+							<section class="col-40">
+								<ul class="download-details">
+									<li class="download"><button class="drop-down">Open</button></li>
+							</ul>
+						</section>
+
+						<ul class="sub-list col-100">
+							<li class="table-row">
+								<section class="col-60">
+									<p>Parallax Exporter for Mac</p>
+								</section>
+								<section class="col-40">
+									<ul class="download-details">
+										<li class="download"><button class="direct-download" value="https://itunespartner.apple.com/assets/downloads/ParallaxExporter_Apps.zip">Download</button></li>
+									</ul>
+								</section>
+							</li>
+
+							<li class="table-row">
+								<section class="col-60">
+									<p>Parallax Exporter for Windows</p>
+								</section>
+								<section class="col-40">
+									<ul class="download-details">
+										<li class="download"><button class="direct-download" value="https://itunespartner.apple.com/assets/downloads/ParallaxExporter_Windows.zip">Download</button></li>
+									</ul>
+								</section>
+							</li>
+						</ul>
+					</li>
+
+						<!-- Parallax Previewer -->
+						<li class="table-row">
+							<section class="col-60">
+								<p>Parallax Previewer</p>
+								<p class="smaller">Use Parallax Previewer to preview layered Photoshop files, assemble individual image layers from PNG files and preview the parallax effect, or preview layered images exported by the Parallax Exporter plug-in.</p>
+							</section>
+							<section class="col-40">
+								<ul class="download-details">
+									<li class="build-number">1A68</li>
+									<li class="published-date">Jan 25, 2016</li>
+									<li class="download"><button class="direct-download" value="http://itunespartner.apple.com/assets/downloads/Parallax%20Previewer.dmg">Download</button></li>
+								</ul>
+							</section>
+						</li>
+
+
+					</ul>
+				</section> <!-- // END BETA TABLE -->
+			</div>
+
+			<!-- Release TABLE -->
+			<div class="row">
+				<section class="table">
+					<section class="table-top-sticky">
+						<section class="table-header">
+							<section class="col-60">
+
+								<!-- Table title -->
+								<span>Release Software</span>
+
+							</section>
+							<section class="col-40">
+							<ul class="download-details">
+								<li class="release-notes">&nbsp;</li>
+								<li class="build-number">Build</li>
+								<li class="published-date">Date</li>
+								<li class="download">&nbsp;</li>
+							</ul>
+						</section>
+					</section>
+					</section>
+
+					<ul class="table-rows">
+
+						<!-- XCODE -->
+						<li class="table-row">
+							<section class="col-60">
+								<!--<img class="left margin-right-small" src="/assets/elements/icons/xcode-beta/xcode-beta-64x64.png" height="32" width="32" alt=""/>-->
+								<p><span class="platform-title">Xcode</span> 7.3.1</p>
+								<p class="smaller">Includes iOS, OS X, watchOS, and tvOS SDKs.</p>
+							</section>
+							<section class="col-40">
+								<ul class="download-details">
+									<li class="release-notes"><a href="/go/?id=xcode-7.3.1-rn">Release Notes</a></li>
+									<li class="build-number">7D1014</li>
+									<li class="published-date">May 3, 2016</li>
+									<li class="download"><button class="direct-download" value="https://itunes.apple.com/us/app/xcode/id497799835?ls=1&mt=12">Download</button></li>
+								</ul>
+							</section>
+						</li>
+
+						<!-- OS X -->
+						<li class="table-row">
+							<section class="col-60">
+								<p><span class="platform-title">OS X</span>  10.11.5</p>
+								<p class="smaller hidden">App Store Redemption Code: <span data-promo-id="RGG4T9847SU"></span></p>
+							</section>
+							<section class="col-40">
+								<ul class="download-details">
+									<li class="build-number">15F34</li>
+									<li class="published-date">May 16, 2016</li>
+									<li class="download"><button class="direct-download" value="https://itunes.apple.com/us/app/os-x-el-capitan/id1018109117?mt=12">Download</button></li>
+								</ul>
+							</section>
+						</li>
+
+						<!-- iOS 9 -->
+						<li class="table-row">
+							<section class="col-60">
+								<!--<img class="left margin-right-small" src="/assets/elements/icons/ios-9/ios-9-64x64.png" height="32" width="32" alt=""/>-->
+								<p><span class="platform-title">iOS</span> 9.3.2</p>
+							</section>
+							<section class="col-40">
+								<ul class="download-details">
+									<li class="build-number">13F69</li>
+									<li class="published-date">May 16, 2016</li>
+									<li class="download"><button class="drop-down">Open</button></li>
+								</ul>
+							</section>
+
+							<!-- iOS 9 DOWNLOADS -->
+							<ul class="sub-list col-100">
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPhone SE</p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-61688-20160516-6A0F5782-13A7-11E6-93C9-A4D6400DF7EB/iPhone8,4_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPhone 6s</p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-62431-20160516-5E51F038-13A9-11E6-ACFA-61D9400DF7EB/iPhone8,1_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPhone 6s Plus</p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-62657-20160516-02ECC2F8-13AA-11E6-AFB3-D9DA400DF7EB/iPhone8,2_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPhone 6</p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download"  value="http://appldnld.apple.com/ios9.3.2/031-62241-20160516-160872B6-13A9-11E6-B051-13D9400DF7EB/iPhone7,2_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPhone 6 Plus</p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-61608-20160516-6A0E619C-13A7-11E6-BC36-9ED6400DF7EB/iPhone7,1_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPhone 5s <span class="lighter">(Model A1453, A1533)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-62564-20160516-7F3CEE38-13A9-11E6-ADCF-CED9400DF7EB/iPhone6,1_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPhone 5s <span class="lighter">(Model A1457, A1518, A1528, A1530)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-62603-20160516-87388660-13A9-11E6-A9DA-F8D9400DF7EB/iPhone6,2_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPhone 5c <span class="lighter">(Model A1456, A1532)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-61599-20160516-6A0E265A-13A7-11E6-A36D-9CD6400DF7EB/iPhone5,3_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPhone 5c <span class="lighter">(Model A1507, A1516, A1526, A1529)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-61589-20160516-6A0DB742-13A7-11E6-8EF1-9AD6400DF7EB/iPhone5,4_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPhone 5 <span class="lighter">(Model A1428)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-62167-20160516-CFF6D768-13A8-11E6-A516-5BD8400DF7EB/iPhone5,1_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPhone 5 <span class="lighter">(Model A1429)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-61503-20160516-6A0BAB96-13A7-11E6-AAB4-8ED6400DF7EB/iPhone5,2_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPhone 4s</p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-62190-20160516-E6F57D7A-13A8-11E6-BDFF-CBD8400DF7EB/iPhone4,1_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPod touch <span class="lighter">(5th generation)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-62317-20160516-5663E73C-13A9-11E6-8DBC-3CD9400DF7EB/iPod5,1_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPod touch <span class="lighter">(6th generation)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-61974-20160516-6A10682A-13A7-11E6-8804-B2D6400DF7EB/iPod7,1_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+								
+								<li class="table-row">
+									<section class="col-60">
+										<p>9.7-inch iPad Pro <span class="lighter">(Wi-Fi)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-63513-20160531-52E11156-2665-11E6-8860-F0F5662719FC/iPad6,3_9.3.2_13F72_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>9.7-inch iPad Pro <span class="lighter">(Wi-Fi + Cellular)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-63521-20160531-52E11160-2665-11E6-8860-F1F5662719FC/iPad6,4_9.3.2_13F72_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>12.9-inch iPad Pro <span class="lighter">(Wi-Fi)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-62618-20160516-D6E79C64-13A9-11E6-9BD6-45DA400DF7EB/iPad6,7_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>12.9-inch iPad Pro <span class="lighter">(Wi-Fi + Cellular)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-62062-20160516-6A1A9458-13A7-11E6-8779-B8D6400DF7EB/iPad6,8_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad mini 4 <span class="lighter">(Wi-Fi)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-61525-20160516-6A0CDDA4-13A7-11E6-B5B7-92D6400DF7EB/iPad5,1_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad mini 4 <span class="lighter">(Wi-Fi + Cellular)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-61853-20160516-6A119AA6-13A7-11E6-B860-AED6400DF7EB/iPad5,2_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad Air 2 <span class="lighter">(Model A1566)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-61962-20160516-6A10E836-13A7-11E6-BCE4-B0D6400DF7EB/iPad5,3_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad Air 2 <span class="lighter">(Model A1567)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-62058-20160516-6A155D62-13A7-11E6-B897-B7D6400DF7EB/iPad5,4_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad mini 3 <span class="lighter">(Model A1599)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-61717-20160516-6A11028A-13A7-11E6-86CE-A8D6400DF7EB/iPad4,7_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad mini 3 <span class="lighter">(Model A1600)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-61583-20160516-6A0C7EA4-13A7-11E6-8E0F-96D6400DF7EB/iPad4,8_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad mini 3 <span class="lighter">(Model A1601)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-62637-20160516-F4A172DE-13A9-11E6-B42D-9BDA400DF7EB/iPad4,9_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad Air <span class="lighter">(Model A1474)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-62625-20160516-EE9553BA-13A9-11E6-93F4-6BDA400DF7EB/iPad4,1_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad Air <span class="lighter">(Model A1475)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-61504-20160516-6A0CB70C-13A7-11E6-A531-90D6400DF7EB/iPad4,2_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad Air <span class="lighter">(Model A1476)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-62614-20160516-CB464BF8-13A9-11E6-B641-1EDA400DF7EB/iPad4,3_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad mini 2 <span class="lighter">(Model A1489)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-62477-20160516-7C75A19A-13A9-11E6-BA2A-BAD9400DF7EB/iPad4,4_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad mini 2 <span class="lighter">(Model A1490)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-62184-20160516-D28FBBF2-13A8-11E6-9EED-7DD8400DF7EB/iPad4,5_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad mini 2 <span class="lighter">(Model A1491)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-61806-20160516-6A0E99F0-13A7-11E6-8620-ACD6400DF7EB/iPad4,6_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad <span class="lighter">(4th generation Model A1458)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-62044-20160516-6A13F7E2-13A7-11E6-8AE1-B5D6400DF7EB/iPad3,4_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad <span class="lighter">(4th generation Model A1459)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-61801-20160516-6A0E0C1A-13A7-11E6-9983-AAD6400DF7EB/iPad3,5_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad <span class="lighter">(4th generation Model A1460)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-62189-20160516-DA2C1F0E-13A8-11E6-AE96-A5D8400DF7EB/iPad3,6_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad mini<span class="lighter">(Model A1432)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-61685-20160516-6A0F6060-13A7-11E6-A5F6-A2D6400DF7EB/iPad2,5_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad mini<span class="lighter">(Model A1454)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-61584-20160516-6A0CDF20-13A7-11E6-B5B7-98D6400DF7EB/iPad2,6_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad mini<span class="lighter">(Model A1455)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-61710-20160516-6A0F5728-13A7-11E6-9570-A7D6400DF7EB/iPad2,7_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad Wi-Fi <span class="lighter">(3rd generation)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-62432-20160516-64D23986-13A9-11E6-83B9-86D9400DF7EB/iPad3,1_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad Wi-Fi + Cellular <span class="lighter">(model for ATT)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-61572-20160516-6A0BABB4-13A7-11E6-AAB4-94D6400DF7EB/iPad3,3_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad Wi-Fi + Cellular <span class="lighter">(model for Verizon)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-62077-20160516-8B3D488C-13A8-11E6-93B1-32D8400DF7EB/iPad3,2_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad 2 Wi-Fi <span class="lighter">(Rev A)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-61483-20160516-6A0B5EB6-13A7-11E6-BE17-8CD6400DF7EB/iPad2,4_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad 2 Wi-Fi</p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-61477-20160516-6A0A9404-13A7-11E6-AB79-8AD6400DF7EB/iPad2,1_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad 2 Wi-Fi + 3G <span class="lighter">(GSM)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-61682-20160516-6A0D271E-13A7-11E6-A0AD-A1D6400DF7EB/iPad2,2_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+								<li class="table-row">
+									<section class="col-60">
+										<p>iPad 2 Wi-Fi + 3G <span class="lighter">(CDMA)</span></p>
+									</section>
+									<section class="col-40">
+										<ul class="download-details">
+											<li class="download"><button class="direct-download" value="http://appldnld.apple.com/ios9.3.2/031-62042-20160516-6A0FFCFA-13A7-11E6-992F-B3D6400DF7EB/iPad2,3_9.3.2_13F69_Restore.ipsw">Download</button></li>
+										</ul>
+									</section>
+								</li>
+
+							</ul>
+
+						</li>
+
+						<!-- tvOS -->
+						<li class="table-row">
+							<section class="col-60">
+								<p><span class="platform-title">tvOS</span> 9.2.1</p>
+							</section>
+							<section class="col-40">
+								<ul class="download-details">
+									<li class="build-number">13Y772</li>
+									<li class="published-date">May 16, 2016</li>
+									<li class="download"><button class="direct-download" value="http://appldnld.apple.com/tvos9.2.1/031-46327-20160516-FFB07AF6-13CE-11E6-AE7B-93E0400DF7EB/AppleTV5,3_9.2.1_13Y772_Restore.ipsw">Download</button></li>
+								</ul>
+							</section>
+						</li>
+
+						<!-- OS X SERVER -->
+						<li class="table-row">
+							<section class="col-60">
+								<p><span class="platform-title">OS X Server</span> 5.1.5</p>
+								<p class="smaller hidden">App Store Redemption Code: <span data-promo-id="RGG4THX5SU"></span></p>
+							</section>
+							<section class="col-40">
+								<ul class="download-details">
+									<li class="build-number">15S7047</li>
+									<li class="published-date">May 16, 2016</li>
+									<li class="download"><button data-promo-id="RGG4THX5SU">Download</button></li>
+								</ul>
+							</section>
+						</li>
+
+					</ul>
+				</section> <!-- // END RELEASE TABLE -->
+			</div>
+
+
+
+			<div class="row">
+				<div class="col-100 no-padding-bottom">
+					<h5>Installation Guides and Acknowledgements</h5>
+				</div>
+			</div>
+			<div class="row divider-top">
+				<div class="col-50 no-padding-bottom">
+					<ul class="links small">
+						<h6>iOS</h6>
+						<li class="library"><a href="/go/?id=install-ios-beta">iOS beta Software Installation Guide</a></li>
+						<li class="library"><a href="/go/?id=ios-10.0-acknowledgements">Swift Playgrounds Acknowledgements</a></li>
+
+						<h6>watchOS</h6>
+						<li class="library"><a href="/go/?id=install-watchos-beta">watchOS beta Software Installation Guide</a></li>
+					</ul>
+				</div>
+				<div class="col-50 no-padding-bottom">
+					<ul class="links small">
+						<h6>tvOS</h6>
+						<li class="library"><a href="/go/?id=install-tvos-beta">tvOS beta Software Installation Guide</a></li>
+					</ul>
+				</div>
+			</div>
+		</section>
+
+		
+
+
+	</main>
+
+	<div class="bg-light">
+		<aside class="grid">
+			<section id="router" class="router">
+				<a href="/download/more/" class="block row">
+					<span class="col-100 text-center">
+						<span class="two-lines">
+							<h4>
+								<small>Don't see what you're looking for?</small>
+								See more downloads
+							</h4>
+						</span>
+					</span>
+				</a>
+			</section>
+		</aside>
+	</div>
+
+
+	<section id="globalfooter-wrapper">
+	<footer id="globalfooter" role="contentinfo">
+		<nav class="footer-breadory">
+			<a href="/" class="home breadcrumbs-home"><span aria-hidden="true"></span><span class="breadcrumbs-home-label">Developer</span></a>
+			<section class="breadcrumbs">
+				<ol class="breadcrumbs-list">
+					<li>Download</li>
+				</ol>
+			</section>
+			<div id="directorynav" class="directorynav">
+	<div id="dn-cola" class="column">
+		<h3><a href="/discover/">Discover</a></h3>
+		<ul>
+			<li><a href="/macos/">macOS</a></li>
+			<li><a href="/ios/">iOS</a></li>
+			<li><a href="/watchos/">watchOS</a></li>
+			<li><a href="/tvos/">tvOS</a></li>
+			<li><a href="/programs/">Developer Program</a></li>
+			<li><a href="/enterprise/">Enterprise</a></li>
+			<li><a href="/education/">Education</a></li>
+		</ul>
+
+	</div>
+	<div id="dn-colb" class="column">
+		<h3><a href="/design/">Design</a></h3>
+		<ul>
+			<li><a href="/accessibility/">Accessibility</a></li>
+			<li><a href="/cases/">Accessories</a></li>
+			<li><a href="/design/adaptivity/">Adaptivity</a></li>
+			<li><a href="/design/awards/">Apple Design Awards</a></li>
+			<li><a href="/fonts/">Fonts</a></li>
+			<li><a href="/videos/design/">Design Videos</a></li>
+			<li><a href="/app-store/marketing/guidelines/">Marketing Guidelines</a></li>
+		</ul>
+	</div>
+	<div id="dn-colc" class="column">
+		<h3><a href="/develop/">Develop</a></h3>
+		<ul>
+			<li><a href="/xcode/">Xcode</a></li>
+			<li><a href="/swift/">Swift</a></li>
+			<li><a href="/download/">Downloads</a></li>
+			<li><a href="/reference/">API Reference</a></li>
+			<li><a href="/library/prerelease/content/navigation/">Guides</a></li>
+			<li><a href="/library/prerelease/content/navigation/#section=Resource%20Types&topic=Sample%20Code">Sample Code</a></li>
+			<li><a href="/videos/">Videos</a></li>
+		</ul>
+
+	</div>
+	<div id="dn-cold" class="column">
+		<h3><a href="/distribute/">Distribute</a></h3>
+		<ul>
+			<li><a href="/app-store/">App Store</a></li>
+			<li><a href="/app-store/review/">App Review</a></li>
+			<li><a href="https://itunesconnect.apple.com/">iTunes Connect</a></li>
+			<li><a href="/testflight/">TestFlight</a></li>
+			<li><a href="/enterprise/">Enterprise</a></li>
+			<li><a href="/safari/extensions/">Safari Extensions</a></li>
+		</ul>
+	</div>
+	<div id="dn-cole" class="column">
+		<h3><a href="/support/">Support</a></h3>
+		<ul>
+			<li><a href="https://forums.developer.apple.com">Developer Forums</a></li>
+			<li><a href="/contact/">Contact Us</a></li>
+			<li><a href="/bug-reporting/">Bug Reporting</a></li>
+			<li><a href="/terms/">License Agreements</a></li>
+			<li><a href="/system-status/">System Status</a></li>
+		</ul>
+	</div>
+</div>
+
+		</nav>
+		<div class="ac-gf-footer-legal">
+  <div class="ac-gf-footer-news"> To receive the latest developer news, visit and subscribe to our <a href="/news/">News and Updates</a>. </div>
+  <div class="ac-gf-footer-legal-copyright">Copyright © 2016 Apple Inc. All rights reserved.</div>
+  <div class="ac-gf-footer-legal-links">
+    <a href="https://www.apple.com/legal/internet-services/terms/site.html" class="first">Terms of Use</a>
+    <a href="https://www.apple.com/privacy/privacy-policy/">Privacy Policy</a>
+    <a href="/bug-reporting/">Report Bugs</a>
+    <a href="/contact/submit/">Feedback</a>
+  </div>
+</div>
+
+	</footer>
+</section>
+
+</body>
+</html>

--- a/spec/prerelease_spec.rb
+++ b/spec/prerelease_spec.rb
@@ -76,5 +76,12 @@ module XcodeInstall
       prereleases.count.should == 1
       prereleases.first.should == Xcode.new('8 beta', '/services-account/download?path=/WWDC_2016/Xcode_8_beta/Xcode_8_beta.xip', '/go/?id=xcode-8-beta-rn')
     end
+
+    it 'can parse prereleases from 20160705' do
+      prereleases = parse_prereleases('20160705')
+
+      prereleases.count.should == 1
+      prereleases.first.should == Xcode.new('8 beta 2', '/services-account/download?path=/Developer_Tools/Xcode_8_beta_2/Xcode_8_beta_2.xip', '/go/?id=xcode-8-beta-rn')
+    end
   end
 end


### PR DESCRIPTION
Was a tiny regex fix to include the extra 'beta 2' here. It could probably be optimized in terms of instead extracting out a matched group, but I opted to keep the same scan/sub logic instead. This should address #143. Thanks for your consideration!